### PR TITLE
Add construct_dataset which uses WebDataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ transformers/
 BID*
 classifiers/
 *.pkl_*
+*.tar
 npi_models
 test_out
 

--- a/src/npi/config.py
+++ b/src/npi/config.py
@@ -2,23 +2,54 @@ import torch
 
 
 # TODO: Make sure save folder actually exists. Raise an error if it doesn't
+
+
+LM_CONFIG_DICT = {'gpt2': {'total_layers': 13, 'm': 768},
+                'gpt2-medium': {'total_layers': 25, 'm': 1024}}
 class NPIConfig:
     def __init__(
         self,
         device: torch.device = None,
         gpt_model="gpt2",
         npi_type="adversarial",
-        save_folder="models/npi_models/",
+        model_save_folder="models/npi_models/",
+        dataset_folder="data/processed/",
+        npi_name="cat_induction",
         batch_size=10,
         perturbation_indices=[5, 11],
+        window_size=10,
         max_seq_len=10,
         num_seq_iters=10,
+        top_k=1,
+        top_p=0.9,
     ):
         self.gpt_model = gpt_model
         self.npi_type = npi_type
-        self.save_folder = save_folder
+        self.model_save_folder = (
+            model_save_folder
+            if model_save_folder.endswith("/")
+            else model_save_folder + "/"
+        )
+        self.dataset_folder = (
+            dataset_folder if dataset_folder.endswith("/") else dataset_folder + "/"
+        )
+        self.npi_name = npi_name
+        self.dataset_file = self.dataset_folder + self.npi_name + ".tar"
         self.batch_size = batch_size
         self.perturbation_indices = perturbation_indices
+        self.window_size = window_size
         self.max_seq_len = max_seq_len
         self.num_seq_iters = num_seq_iters
         self.device = device
+
+        self.top_k = top_k
+        self.top_p = top_p
+
+        lm_config = LM_CONFIG_DICT[gpt_model]
+        self.num_total_layers = lm_config['total_layers']
+        self.m = lm_config['m']
+
+        # Calculate n from pis
+        self.n = len(perturbation_indices) * max_seq_len * num_seq_iters  # could be 200
+
+        self.k = 1 #TODO: configure this when actually in use.

--- a/src/npi/dataset/construct_dataset.py
+++ b/src/npi/dataset/construct_dataset.py
@@ -1,0 +1,194 @@
+import copy
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from tqdm import tqdm
+import webdataset as wds
+from npi.config import NPIConfig
+from npi.transformers.modeling_gpt2 import GPT2LMHeadModel
+from npi.transformers.tokenization_gpt2 import GPT2Tokenizer
+from npi.utils import top_k_top_p_filtering
+
+
+class NPIDatasetConstructor:
+    def __init__(self, config: NPIConfig) -> None:
+        self.save_file = config.dataset_file
+        if "gpt2" in config.gpt_model:
+            self.model = GPT2LMHeadModel.from_pretrained(config.gpt_model)
+            self.tokenizer = GPT2Tokenizer.from_pretrained(config.gpt_model)
+        else:
+            raise NotImplementedError(f"model_name == {config.gpt_model} not supported")
+
+        self.device = config.device
+        if torch.cuda.is_available():
+            print(f"Using cuda:{torch.cuda.current_device()}")
+            print(f"gpu_device is {self.device}")
+            self.model = self.model.cuda(device=self.device)
+
+        self.window_size = config.window_size
+        self.perturb_indicies = config.perturbation_indices
+        self.num_iters = config.num_seq_iters
+        self.max_iters = 5 * self.num_iters
+        self.top_k = config.top_k
+        self.top_p = config.top_p
+
+    def construct_target_word_dataset(self):
+        # TODO: Logic for creating target word dataset.
+        pass
+
+    def construct_dataset(self, data_iter, data_len):
+        sink = wds.TarWriter(self.save_file)
+
+        # necessary to pull activation tensors
+        self.model.transformer.output_hidden_states = True
+
+        pbar = tqdm(
+            data_iter, total=data_len, mininterval=10, maxinterval=30, miniters=100
+        )
+        try:
+            for index, (line, cls) in enumerate(pbar):
+                if index == data_len:  # Break if reached amount of data to generate.
+                    break
+
+                # clean line to some extent
+                #   (due to possible differences in corpora that could tip off the classifer)
+                line = line.lower().strip().strip(".").strip()
+                if len(line.split()) > 100 or len(line.split()) < 4:
+                    continue
+
+                big_array = []  # nxmx1
+
+                tokens = self.tokenizer.encode(line)
+                tokens = tokens[-self.window_size :]
+                num_tokens_needed = self.window_size - len(tokens)
+                tokens = torch.tensor(tokens, dtype=torch.long, device=self.device)
+                tokens = tokens.unsqueeze(0).repeat(1, 1)
+                tokens = tokens.cuda(device=self.device)
+                all_text_tokens = copy.deepcopy(tokens)
+
+                # some constants to set first
+                len_for_big_array = len(self.perturb_indicies) * self.num_iters
+
+                # We loop through multiple times now
+                purely_generated_tokens = []  # haven't generated anything yet
+                i = -1
+                while True:
+                    i += 1
+
+                    tokens, next_token = self.generate_tokens(big_array, tokens)
+                    purely_generated_tokens = (
+                        purely_generated_tokens + next_token.tolist()
+                    )
+                    all_text_tokens = torch.cat(
+                        (all_text_tokens, next_token.unsqueeze(0)), dim=1
+                    ).cuda(self.device)
+
+                    if (  # TODO Figure out this condition. It can vary.
+                        len(big_array) >= len_for_big_array
+                        and len(all_text_tokens.squeeze())
+                        >= self.num_iters + self.window_size
+                    ):
+                        break
+
+                num_gpt2_iters_run = i + 1
+                big_array = big_array[-len_for_big_array:]
+
+                # TODO: This currently only allows binary classification
+                # figure out true classification
+                orig_classification = np.zeros(2)
+                if cls == 0:
+                    orig_classification[0] = 1
+                elif cls == 1:
+                    orig_classification[1] = 1
+                else:
+                    raise RuntimeError("Got a score that is not 0 or 1")
+
+                # What will we call "original text" and "generated text"
+
+                assert (
+                    all_text_tokens.squeeze().tolist()[-self.window_size :]
+                    == tokens.squeeze().tolist()
+                )
+
+                orig_text_tokens = all_text_tokens[
+                    :, -self.window_size - self.num_iters : -self.num_iters
+                ]  # sent_len tokens that produced generated_text_tokens
+                generated_text_tokens = tokens
+
+                orig_tokens = orig_text_tokens.squeeze().tolist()
+                gpt2_generated_tokens = generated_text_tokens.squeeze().tolist()
+
+                orig_text = self.tokenizer.decode(orig_tokens)
+                gpt2_generated_text = self.tokenizer.decode(gpt2_generated_tokens)
+
+                # Now the big_array is a list of length (num_iters*len(perturb_indicies)) of tensors with shape (1,sent_len,emb_dim)
+                big_array = torch.cat(big_array, dim=1)
+                big_array = big_array.permute(
+                    1, 2, 0
+                )  # shape is (2*sent_len*num_iters, emb_dim, 1) now, emb_dim will be 1024 or 768
+                big_array = big_array.data.cpu().numpy()
+
+                sink.write(
+                    {
+                        "__key__": "sample%06d" % index,
+                        "orig_activ.npy": big_array,
+                        "orig_label.npy": orig_classification,
+                        "orig.txt": orig_text,
+                        "generated.txt": gpt2_generated_text,
+                        "target.txt": "target words",  # TODO: This may not be needed, or needed for word avoidance/induction
+                        "orig_tokens.pyd": orig_tokens,
+                        "metadata.pyd": {
+                            "num_gpt2_iters": num_gpt2_iters_run,
+                            "gpt2_generated_tokens": gpt2_generated_tokens,
+                        },
+                    }
+                )
+
+                # TODO: Print out how many of each classified data is constructed.
+                pbar.update()
+
+        except:
+            raise
+        finally:
+            torch.cuda.empty_cache()
+            print("Closing dataset writer")
+            sink.close()
+
+        torch.cuda.empty_cache()
+        print(" ", flush=True)
+        print("done")
+
+    def generate_tokens(self, big_array, tokens):
+        # Now run the model
+        hidden_states, _, all_hiddens = self.model(
+            input_ids=tokens[:, -self.window_size :]
+        )  # all_hiddens is a list of len
+
+        # 25 or 13 with tensors of shape (gpt2 medium or small)
+        # (1,sent_len,1024) or (1,sent_len,768)
+        # Add to big_array
+        if tokens.shape[1] >= self.window_size:
+            for pi in self.perturb_indicies:
+                big_array.append(all_hiddens[pi].data)
+
+        # Now we extract the new token and add it to the list of tokens
+        next_token_logits = hidden_states[0, -1, :]
+        filtered_logits = top_k_top_p_filtering(
+            next_token_logits, top_k=self.top_k, top_p=self.top_p
+        )
+        next_token = torch.multinomial(
+            F.softmax(filtered_logits, dim=-1), num_samples=1
+        )
+
+        # ...update list of tokens
+        if tokens.shape[1] < self.window_size:
+            tokens = torch.cat((tokens, next_token.unsqueeze(0)), dim=1).cuda(
+                self.device
+            )
+        else:
+            tokens = torch.cat((tokens[:, 1:], next_token.unsqueeze(0)), dim=1).cuda(
+                self.device
+            )
+
+        return tokens, next_token

--- a/src/npi/dataset/construct_politics_data.py
+++ b/src/npi/dataset/construct_politics_data.py
@@ -8,6 +8,8 @@
 
 import argparse
 import torch
+from npi.config import NPIConfig
+from npi.dataset.construct_dataset import NPIDatasetConstructor
 from npi.dataset.construct_sentiment_data import construct_sentiment_data
 import pandas as pd
 
@@ -19,11 +21,17 @@ view: number
 text: str
 """
 
-def construct_politics_data(model_layers, data, gpu_device_num, pkl_name):
+def construct_politics_data(model_layers, data, gpu_device_num):
     data_iter = zip(data['text'], data['view'])
     device = torch.device(F"cuda:{gpu_device_num}")
-    construct_sentiment_data(model_layers=model_layers, data_iter=data_iter, data_len=len(data), gpu_device=device,
-                                 pkl_name=pkl_name, model_name="gpt2", window_size=10, num_iters=10, num_chunks=40)
+    config = NPIConfig(
+        device,
+        gpt_model="gpt2",
+        perturbation_indices=model_layers,
+        npi_name="politics"
+    )
+    construct_data = NPIDatasetConstructor(config)
+    construct_data.construct_dataset(data_iter, len(data))
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -34,20 +42,20 @@ if __name__ == "__main__":
 
     model_layers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] 
     if args.view == "both":
-        with open("NewB/train_orig.txt", 'r', newline='') as f:
+        with open("data/external/NewB/train_orig.txt", 'r', newline='') as f:
             data = pd.read_csv(f, delimiter="\t")
             data["view"] = data["view"].replace(
                 to_replace={0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1})
             data = data[data.view != 5]
             data = data.sample(frac=1)
-            construct_politics_data(model_layers, data, 1, "data/politics/sentence_arrays.pkl")
+            construct_politics_data(model_layers, data, 1)
     elif (args.view == "liberal"):
         with open("NewB/liberal.txt", 'r', newline='') as f:
             data = pd.read_csv(f, delimiter="\t")
-            construct_politics_data(model_layers, data, 0, "data/politics/liberal/sentence_arrays.pkl")
+            construct_politics_data(model_layers, data, 0)
     else:    
         with open("NewB/conservative.txt", 'r', newline='') as f:
             data = pd.read_csv(f, delimiter="\t")
             data["view"] = data["view"].replace(
                 to_replace={0: 1})
-            construct_politics_data(model_layers, data, 1, "data/politics/conservative/sentence_arrays.pkl")
+            construct_politics_data(model_layers, data, 1)

--- a/src/npi/dataset/construct_sentiment_data.py
+++ b/src/npi/dataset/construct_sentiment_data.py
@@ -15,7 +15,7 @@ import numpy as np
 
 import torch
 import torch.nn.functional as F
-from transformers import GPT2LMHeadModel, GPT2Tokenizer
+from npi.transformers import GPT2LMHeadModel, GPT2Tokenizer
 from tqdm import tqdm
 import faulthandler # Debugging segfaults
 

--- a/src/npi/dataset/npi_dataset.py
+++ b/src/npi/dataset/npi_dataset.py
@@ -1,20 +1,90 @@
+import tarfile
 import numpy as np
 import torch
 
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import IterableDataset, Dataset, DataLoader
+import webdataset as wds
 
 from npi.config import NPIConfig
 
 torch.manual_seed(1)
 
-LM_CONFIG_DICT = {'gpt2': {'total_layers': 13, 'm': 768},
-                'gpt2-medium': {'total_layers': 25, 'm': 1024}}
+LM_CONFIG_DICT = {
+    "gpt2": {"total_layers": 13, "m": 768},
+    "gpt2-medium": {"total_layers": 25, "m": 1024},
+}
 
 ORIG_ACTIV_INDEX = 0
 ORIG_LABEL_INDEX = 1
 TARG_LABEL_INDEX = 2
 LANG_MODEL_INDEX = 3
 META_DATA_INDEX = 4
+
+
+class NPIDatasetLoader:
+    def __init__(self, config: NPIConfig, split_ratio=0.25) -> None:
+        self.config = config
+        with tarfile.open(config.dataset_file, mode="r") as f:
+            self.total = len(f.getmembers()) // 7
+        self.split = int(self.total * (1 - split_ratio))
+        dataset_decoder = (
+            lambda key, data: extract_needed_layers(
+                wds.autodecode.basichandlers(key, data),
+                self.config.perturbation_indices,
+                self.config.num_total_layers,
+                self.config.max_seq_len,
+                self.config.num_seq_iters,
+            )
+            if "orig_activ" in key
+            else np.array(wds.autodecode.basichandlers(key, data))
+            if "orig_tokens" in key
+            else wds.autodecode.basichandlers(key, data)
+        )
+        self.dataset: IterableDataset = (
+            wds.WebDataset(config.dataset_file)
+            .slice(0, self.split)
+            .decode(
+                post=[dataset_decoder],
+                only=["orig_activ.npy", "orig_tokens.pyd", "orig.txt", "generated.txt"],
+            )
+            .to_tuple("orig_activ.npy orig_tokens.pyd orig.txt generated.txt")
+            .batched(1000)
+        )
+
+        self.test_dataset: IterableDataset = (
+            wds.WebDataset(config.dataset_file)
+            .slice(self.split, self.total)
+            .decode(
+                post=[dataset_decoder],
+                only=["orig_activ.npy", "orig_tokens.pyd", "orig.txt", "generated.txt"],
+            )
+            .to_tuple("orig_activ.npy orig_tokens.pyd orig.txt generated.txt")
+            .batched(1000)
+        )
+
+    def load_train_and_test_dataloaders(self, batch_size=5):
+        return (
+            # TODO: Can optimize the dataloader here
+            # DataLoader(
+            #     self.dataset, batch_size=batch_size, pin_memory=True, drop_last=True
+            # ),
+            # DataLoader(
+            #     self.test_dataset,
+            #     batch_size=batch_size,
+            #     pin_memory=True,
+            #     drop_last=True,
+            # ),
+            wds.WebLoader(self.dataset, batch_size=None)
+            .unbatched()
+            .shuffle(1000)
+            .batched(batch_size, partial=False),
+            wds.WebLoader(self.test_dataset, batch_size=None)
+            .unbatched()
+            .shuffle(1000)
+            .batched(batch_size, partial=False),
+            (self.split - 1) // batch_size,
+            (self.total - self.split) // batch_size,
+        )
 
 def extract_needed_layers(array, pis, num_total_layers=13, seq_len=10, num_iters=10):
     """
@@ -32,7 +102,9 @@ def extract_needed_layers(array, pis, num_total_layers=13, seq_len=10, num_iters
             pis[i] = num_total_layers + pis[i]  # Should be good now
 
     original_length = array.shape[0]
-    assert original_length == num_total_layers * seq_len * num_iters  # Should contain all layers originally (recommended)
+    assert (
+        original_length == num_total_layers * seq_len * num_iters
+    )  # Should contain all layers originally (recommended)
     all_layers_len_for_one_iter = original_length / num_iters
     # We construct a mask for the large array
     mask = np.array([False for _ in range(original_length)])
@@ -49,16 +121,23 @@ def extract_needed_layers(array, pis, num_total_layers=13, seq_len=10, num_iters
 
 
 class NPIDataSet(Dataset):
-    def __init__(self, dataset, config: NPIConfig, return_row=False, permitted_rows=None, start_index=0):
+    def __init__(
+        self,
+        dataset,
+        config: NPIConfig,
+        return_row=False,
+        permitted_rows=None,
+        start_index=0,
+    ):
         """
         Assumes input dataset is of the form:
-            [[language_model_activations, 
-              activations_classification, 
-              target_classification (no longer used), 
-              language_model_type, 
+            [[language_model_activations,
+              activations_classification,
+              target_classification (no longer used),
+              language_model_type,
               meta_data,
               ...
-            ],  
+            ],
             ...]
         With objects of the following types:
             language_model_activations : nxmx1 ndarray representing flattened activation sequences (required)
@@ -68,25 +147,19 @@ class NPIDataSet(Dataset):
             meta_data : dict recording desired metadata (required for NPI training later)
         """
         self.return_row = return_row
-        self.seq_len = config.max_seq_len 
-        self.num_iters = config.num_seq_iters  
+        self.seq_len = config.max_seq_len
+        self.num_iters = config.num_seq_iters
 
         lm_config = LM_CONFIG_DICT[config.gpt_model]
-        self.num_total_layers = lm_config['total_layers']
-        self.m = lm_config['m']
+        self.num_total_layers = lm_config["total_layers"]
+        self.m = lm_config["m"]
 
         # Calculate n from pis
-        self.n = len(config.perturbation_indices) * self.seq_len * self.num_iters  # could be 200
+        self.n = (
+            len(config.perturbation_indices) * self.seq_len * self.num_iters
+        )  # could be 200
 
         # self.masking_coeff = 1e12
-
-        if permitted_rows is None:
-            self.dataset = dataset
-        else:
-            self.dataset = []
-            for i in range(len(dataset)):
-                if start_index + i in permitted_rows:
-                    self.dataset.append(dataset[i])
 
         for i in range(len(self.dataset)):
             # mask the inf values in the activations to simply be VERY VERY LARGE values
@@ -96,17 +169,25 @@ class NPIDataSet(Dataset):
             # cast everything as torch tensors, extract needed layers
             self.dataset[i][ORIG_ACTIV_INDEX] = torch.from_numpy(
                 extract_needed_layers(
-                    self.dataset[i][ORIG_ACTIV_INDEX], pis=config.perturbation_indices, num_total_layers=self.num_total_layers, seq_len=config.max_seq_len, num_iters=config.num_seq_iters)).double()
+                    self.dataset[i][ORIG_ACTIV_INDEX],
+                    pis=config.perturbation_indices,
+                    num_total_layers=self.num_total_layers,
+                    seq_len=config.max_seq_len,
+                    num_iters=config.num_seq_iters,
+                )
+            ).double()
             self.dataset[i][ORIG_LABEL_INDEX] = torch.from_numpy(
-                np.array(self.dataset[i][ORIG_LABEL_INDEX])).double()
+                np.array(self.dataset[i][ORIG_LABEL_INDEX])
+            ).double()
             self.dataset[i][TARG_LABEL_INDEX] = torch.tensor([])  # empty tensor
-        
 
     def __getitem__(self, i):
         acts = self.dataset[i][ORIG_ACTIV_INDEX]
         true_label = self.dataset[i][ORIG_LABEL_INDEX]
         targ = self.dataset[i][TARG_LABEL_INDEX]  # None
-        return (acts, true_label, targ, i) if self.return_row else (acts, true_label, targ)
+        return (
+            (acts, true_label, targ, i) if self.return_row else (acts, true_label, targ)
+        )
 
     def __len__(self):
         return len(self.dataset)
@@ -117,7 +198,9 @@ class NPIDataSet(Dataset):
 
 class NPIDataLoader(DataLoader):
     def __init__(self, data, batch_size, pin_memory):
-        super(NPIDataLoader, self).__init__(data, batch_size=batch_size, pin_memory=pin_memory, drop_last=True)
+        super(NPIDataLoader, self).__init__(
+            data, batch_size=batch_size, pin_memory=pin_memory, drop_last=True
+        )
         self.data = data
 
     def get_row_data(self, dataset_indices):

--- a/src/npi/models/training_models.py
+++ b/src/npi/models/training_models.py
@@ -17,8 +17,8 @@ class NPITrainingModels:
         self.npi_model_path = npi_model_path
         self.content_classifier_path = content_classifier_path
         self.generation_classifier_path = generation_classifier_path
-        self.input_activs_shape = None  # TODO: Get hyperparam from config
-        self.input_targ_shape = None  # TODO: Get hyperparam from config
+        self.input_activs_shape = (config.n, config.m, 1)  
+        self.input_targ_shape = (1, 1)  
 
         self.npi_model = None
         self.content_class_model = None
@@ -93,11 +93,11 @@ class NPITrainingModels:
 
     def save_models(self, epoch="_unk"):
         print("Saving NPI Model")
-        out_path = f"{self.config.save_folder}{self.config.npi_type}_npi_network_epoch{epoch}.bin"
+        out_path = f"{self.config.model_save_folder}{self.config.npi_type}_npi_network_epoch{epoch}.bin"
         torch.save(self.npi_model.state_dict(), out_path)
 
         print("Saving GenerationClassifier Model")
         out_path = (
-            f"{self.config.save_folder}GenerationClassifier_network_epoch{epoch}.bin"
+            f"{self.config.model_save_folder}GenerationClassifier_network_epoch{epoch}.bin"
         )
         torch.save(self.generate_class_model.state_dict(), out_path)

--- a/src/npi/training/test_npi.py
+++ b/src/npi/training/test_npi.py
@@ -20,7 +20,7 @@ from typing import List
 
 from npi.modeling_neural_program_interfaces import GPT2LMHeadModel, GPT2LMWithNPI
 from npi.transformers.tokenization_gpt2 import GPT2Tokenizer
-import npi.utils
+import npi.utils as utils
 #from npi.models.npi import GPT2LMHeadModel, GPT2LMWithNPI
 #from transformers.tokenization_gpt2 import GPT2Tokenizer
 #from npi import utils


### PR DESCRIPTION
# CS 401R NPI Dataset Improvement Report
## Introduction

For the past two weeks, I have been working on streamlining the NPI dataset and seeing if it will improve construct data and training of the NPI. The initial improvement made was that I was able to simplify the complexity of the training code by managing the big dataset outside of the training loop. I used the WebDataset library to help manage the large amount of data that construct_data.py would create. I also ran some tests that saw some promising results. Here is the pull request for reference.

## Method

I used the WebDataset library to construct all data into one single tar file that is not compressed. Inside the tar, files are indexed by name, with each data you wanted to store being its separate file. For example, I created 7 files I found needed during the training of the NPI:

• orig_activ.npy (The “big_array”, storing all the hidden activations)
• orig_label.npy (The label of what the text should be)
• orig.txt (The original text fed into the model)
• generated.txt (The text generated from the model)
• target.txt (Not used for sentiment, but could be used for cat induction/avoidance)
• orig_tokens.pyd (The original tokens, used when creating the perturbations from the NPI)
• metadata.pyd (The generated tokens and number of passthroughs done by the GPT2 model to generate the text. The info here actually isn’t being used)

A key is created by the WebDataset to index the tar file. For example, the first sample of orig_activ.npy is stored as “sample000001orig_activ.npy”. The WebDataset can iterate through and shuffle data if needed. It also has the potential to be able to batch all processes (Currently, there is a part in training the NPI where the code iterate through each entry of the batch). Unfortunately, more work is needed for me to figure out some issues switching over from accessing an array of pickles to a batched dataset for training, so I cannot see the speed improvements for training yet.

## Results

Below are the results I have gathered so far:

|  | Pickle into 1 GB files | WebDataset | 
| ---- | ---- | ---- |
Text entries created in 10 minutes | 1175 | 6503
Average iterations/s by tqdm | 1.95 iters/s | 10.83 iters/s
Training with batch=5 | 1.40 iters/s + 1 sec per pickle | 1.12 iters/s

## Conclusion

It makes sense that we gain a huge speedup constructing data using our WebDataset method. With using the 1 GB pickles we are storing that pickle into memory before writing to a file and releasing it, doing it all in one thread. However, with WebDataset, it puts each entry into the tar immediately using another pipeline (I closed the pipeline when the iterations ended and in a finally block). This frees up the main process to do what its main job was, which is to process text through GPT2. The speedup gain we see is about a factor of 5.

After modifying the training loop to work with our new input, I noticed that there is a slowdown (with batch=5) from 1.40 iters/s to 1.12 iters/s. The 20% decrease seems to be a good tradeoff for the 5x increase of data construction and the convenience of having one file for the dataset. More work could be done to optimize the training loop, such as doing proper batch processing. I also noticed that the iters/sec is faster in the beginning of the training loop, and then slows down. I can also look into that and see there is any optimizations to be done in loading the data.